### PR TITLE
Insert ChatGPT Codex comments

### DIFF
--- a/ttl/am2147.vhd
+++ b/ttl/am2147.vhd
@@ -14,6 +14,7 @@ entity am2147 is
     );
 end am2147;
 
+-- ChatGPT Codex implementation
 architecture ttl of am2147 is
   type ram_t is array (0 to 4095) of std_logic;
   signal ram  : ram_t := (others => '0');

--- a/ttl/am2507.vhd
+++ b/ttl/am2507.vhd
@@ -13,6 +13,7 @@ entity am2507 is
     );
 end am2507;
 
+-- ChatGPT Codex implementation
 architecture ttl of am2507 is
 begin
   process(clk)

--- a/ttl/am252519.vhd
+++ b/ttl/am252519.vhd
@@ -18,6 +18,7 @@ entity am252519 is
     );
 end am252519;
 
+-- ChatGPT Codex implementation
 architecture ttl of am252519 is
   signal reg4 : std_logic_vector(3 downto 0);
 begin

--- a/ttl/am93425a.vhd
+++ b/ttl/am93425a.vhd
@@ -14,6 +14,7 @@ entity am93425a is
     );
 end am93425a;
 
+-- ChatGPT Codex implementation
 architecture ttl of am93425a is
   type ram_t is array (0 to 1023) of std_logic;
   signal ram  : ram_t := (others => '0');

--- a/ttl/am93s48.vhd
+++ b/ttl/am93s48.vhd
@@ -12,6 +12,7 @@ entity am93s48 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of am93s48 is
 begin
   process(all)

--- a/ttl/dm74472.vhd
+++ b/ttl/dm74472.vhd
@@ -13,6 +13,7 @@ entity dm74472 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of dm74472 is
   type rom_t is array (0 to 511) of std_logic_vector(7 downto 0);
   signal rom  : rom_t := (others => (others => '0'));

--- a/ttl/dm8221.vhd
+++ b/ttl/dm8221.vhd
@@ -16,6 +16,7 @@ entity dm8221 is
     );
 end dm8221;
 
+-- ChatGPT Codex implementation
 architecture ttl of dm8221 is
   type ram_t is array (0 to 31) of std_logic_vector(1 downto 0);
   signal ram  : ram_t := (others => (others => '0'));

--- a/ttl/dm9328.vhd
+++ b/ttl/dm9328.vhd
@@ -21,6 +21,7 @@ entity dm9328 is
     );
 end dm9328;
 
+-- ChatGPT Codex implementation
 architecture ttl of dm9328 is
   signal rega : std_logic_vector(7 downto 0) := (others => '0');
   signal regb : std_logic_vector(7 downto 0) := (others => '0');

--- a/ttl/dm942.vhd
+++ b/ttl/dm942.vhd
@@ -14,6 +14,7 @@ entity dm942 is
     );
 end dm942;
 
+-- ChatGPT Codex implementation
 architecture ttl of dm942 is
 begin
   out1 <= not ((g1a1 and g1a2) or (g1b1 and g1b2));

--- a/ttl/ff_dc.vhd
+++ b/ttl/ff_dc.vhd
@@ -13,6 +13,7 @@ entity ff_dc is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of ff_dc is
 begin
   process(clk, clr)

--- a/ttl/im5600.vhd
+++ b/ttl/im5600.vhd
@@ -13,6 +13,7 @@ entity im5600 is
     );
 end im5600;
 
+-- ChatGPT Codex implementation
 architecture ttl of im5600 is
   type rom_t is array (0 to 31) of std_logic_vector(7 downto 0);
   signal rom  : rom_t := (others => (others => '0'));

--- a/ttl/res20.vhd
+++ b/ttl/res20.vhd
@@ -25,6 +25,7 @@ entity res20 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of res20 is
 begin
   r2  <= '1'; r3  <= '1'; r4  <= '1'; r5  <= '1';

--- a/ttl/sip220_330_8.vhd
+++ b/ttl/sip220_330_8.vhd
@@ -13,6 +13,7 @@ entity sip220_330_8 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sip220_330_8 is
 begin
   r2 <= '1'; r3 <= '1'; r4 <= '1';

--- a/ttl/sip330_470_8.vhd
+++ b/ttl/sip330_470_8.vhd
@@ -13,6 +13,7 @@ entity sip330_470_8 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sip330_470_8 is
 begin
   r2 <= '1'; r3 <= '1'; r4 <= '1';

--- a/ttl/sn74181.vhd
+++ b/ttl/sn74181.vhd
@@ -24,6 +24,7 @@ entity sn74181 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sn74181 is
   signal a  : unsigned(3 downto 0);
   signal b  : unsigned(3 downto 0);

--- a/ttl/sn74194.vhd
+++ b/ttl/sn74194.vhd
@@ -18,6 +18,7 @@ entity sn74194 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sn74194 is
   signal reg : std_logic_vector(3 downto 0) := (others => '0');
 begin

--- a/ttl/sn74258.vhd
+++ b/ttl/sn74258.vhd
@@ -23,6 +23,7 @@ entity sn74258 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sn74258 is
 begin
   process(all)

--- a/ttl/sn74283.vhd
+++ b/ttl/sn74283.vhd
@@ -15,6 +15,7 @@ entity sn74283 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sn74283 is
   signal a : unsigned(3 downto 0);
   signal b : unsigned(3 downto 0);

--- a/ttl/sn74373.vhd
+++ b/ttl/sn74373.vhd
@@ -13,6 +13,7 @@ entity sn74373 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sn74373 is
   signal data : std_logic_vector(7 downto 0) := (others => '0');
 begin

--- a/ttl/sn74374.vhd
+++ b/ttl/sn74374.vhd
@@ -13,6 +13,7 @@ entity sn74374 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sn74374 is
   signal data : std_logic_vector(7 downto 0) := (others => '0');
 begin

--- a/ttl/sn7474.vhd
+++ b/ttl/sn7474.vhd
@@ -21,6 +21,7 @@ entity sn7474 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of sn7474 is
 begin
   -- first flip-flop

--- a/ttl/til309.vhd
+++ b/ttl/til309.vhd
@@ -16,6 +16,7 @@ entity til309 is
     );
 end;
 
+-- ChatGPT Codex implementation
 architecture ttl of til309 is
   signal reg : std_logic_vector(3 downto 0) := (others => '0');
 begin


### PR DESCRIPTION
## Summary
- add a `-- ChatGPT Codex implementation` comment before each `architecture ttl` line for various TTL modules

## Testing
- `make -k check` *(fails: No rule to make target `/root/hdlmake.mk/hdlmake.mk`)*