### PR TITLE
Implement event-driven time delay model

### DIFF
--- a/ttl/td100.vhd
+++ b/ttl/td100.vhd
@@ -2,7 +2,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
 
 library ttl;
 use ttl.misc.all;

--- a/ttl/td25.vhd
+++ b/ttl/td25.vhd
@@ -2,7 +2,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
 
 library ttl;
 use ttl.misc.all;

--- a/ttl/td250.vhd
+++ b/ttl/td250.vhd
@@ -2,7 +2,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
 
 library ttl;
 use ttl.misc.all;

--- a/ttl/td50.vhd
+++ b/ttl/td50.vhd
@@ -2,7 +2,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
 
 library ttl;
 use ttl.misc.all;

--- a/ttl/timedelay.vhd
+++ b/ttl/timedelay.vhd
@@ -14,17 +14,14 @@ entity timedelay is
 end timedelay;
 
 architecture behavioral of timedelay is
-
-  signal delayed_buffers : std_logic_vector(taps-1 downto 0) := (others => '0');
-
 begin
 
-  process
-    variable delay : time := initial;
+  process (input)
+    variable delay : time;
   begin
+    delay := initial;
     for i in 0 to taps-1 loop
-      wait for delay;
-      delayed(i) <= input;
+      delayed(i) <= input after delay;
       delay      := delay + increment;
     end loop;
   end process;

--- a/ttl/timedelay_tb.vhd
+++ b/ttl/timedelay_tb.vhd
@@ -19,11 +19,48 @@ begin
     delayed => delayed
     );
 
-  process
+  stimulus : process
   begin
-    wait for 5 ns;
+    input <= '0';
+    wait for 10 ns;
+    input <= '1';
 
-    report "Testbench not implemented!" severity warning;
+    wait for 50 ns;                     -- 10 ns + 50 ns = 60 ns
+    assert delayed(0) = '1';
+    assert delayed(1) = '0';
+    assert delayed(2) = '0';
+    assert delayed(3) = '0';
+    assert delayed(4) = '0';
+
+    wait for 10 ns;                     -- 70 ns
+    assert delayed(1) = '1';
+
+    wait for 10 ns;                     -- 80 ns
+    assert delayed(2) = '1';
+
+    wait for 10 ns;                     -- 90 ns
+    assert delayed(3) = '1';
+
+    wait for 10 ns;                     -- 100 ns
+    assert delayed(4) = '1';
+
+    wait for 20 ns;                     -- 120 ns
+    input <= '0';
+
+    wait for 50 ns;                     -- 170 ns
+    assert delayed(0) = '0';
+
+    wait for 10 ns;                     -- 180 ns
+    assert delayed(1) = '0';
+
+    wait for 10 ns;                     -- 190 ns
+    assert delayed(2) = '0';
+
+    wait for 10 ns;                     -- 200 ns
+    assert delayed(3) = '0';
+
+    wait for 10 ns;                     -- 210 ns
+    assert delayed(4) = '0';
 
     wait;
   end process;


### PR DESCRIPTION
## Summary
- restart timedelay outputs whenever `input` changes
- clean up unused numeric library use in td25/50/100/250
- expand timedelay_tb with assertions to show correct behaviour

## Testing
- `make -C ttl check` *(fails: `/root/hdlmake.mk/hdlmake.mk` not found)*