### PR TITLE
Implement TTL testbench stimuli

### DIFF
--- a/ttl/am93425a_tb.vhd
+++ b/ttl/am93425a_tb.vhd
@@ -45,9 +45,32 @@ begin
 
   process
   begin
-    wait for 5 ns;
+    -- write 1 to address 0
+    ce_n <= '0';
+    we_n <= '0';
+    di   <= '1';
+    a0 <= '0'; a1 <= '0'; a2 <= '0'; a3 <= '0'; a4 <= '0';
+    a5 <= '0'; a6 <= '0'; a7 <= '0'; a8 <= '0'; a9 <= '0';
+    wait for 1 ns;
 
-    report "Testbench not implemented!" severity warning;
+    -- read back
+    we_n <= '1';
+    wait for 1 ns;
+    assert do = '1';
+
+    -- write 0 to address 1
+    we_n <= '0'; di <= '0'; a0 <= '1';
+    wait for 1 ns;
+
+    -- read back
+    we_n <= '1';
+    wait for 1 ns;
+    assert do = '0';
+
+    -- chip disabled
+    ce_n <= '1';
+    wait for 1 ns;
+    assert do = 'Z';
 
     wait;
   end process;

--- a/ttl/dm9328_tb.vhd
+++ b/ttl/dm9328_tb.vhd
@@ -45,9 +45,23 @@ begin
 
   process
   begin
-    wait for 5 ns;
+    -- clear registers
+    clr_n <= '0'; wait for 1 ns; clr_n <= '1';
+    assert aq = '0' and aq_n = '1' and bq = '0' and bq_n = '1';
 
-    report "Testbench not implemented!" severity warning;
+    -- shift ones into register A using ai0
+    asel <= '0'; ai0 <= '1';
+    for i in 0 to 7 loop
+      aclk <= '1'; wait for 1 ns; aclk <= '0'; wait for 1 ns;
+    end loop;
+    assert aq = '1' and aq_n = '0';
+
+    -- shift ones into register B using bi1
+    bsel <= '1'; bi1 <= '1';
+    for i in 0 to 7 loop
+      bclk <= '1'; wait for 1 ns; bclk <= '0'; wait for 1 ns;
+    end loop;
+    assert bq = '1' and bq_n = '0';
 
     wait;
   end process;

--- a/ttl/ff_jk_tb.vhd
+++ b/ttl/ff_jk_tb.vhd
@@ -27,9 +27,27 @@ begin
 
   process
   begin
-    wait for 5 ns;
+    clk <= '0';
 
-    report "Testbench not implemented!" severity warning;
+    -- clear to 0 using JK=01
+    j <= '0'; k <= '1';
+    clk <= '1'; wait for 1 ns; clk <= '0';
+    assert q = '0' and q_n = '1';
+
+    -- set to 1 using JK=10
+    j <= '1'; k <= '0';
+    clk <= '1'; wait for 1 ns; clk <= '0';
+    assert q = '1' and q_n = '0';
+
+    -- reset to 0 using JK=01
+    j <= '0'; k <= '1';
+    clk <= '1'; wait for 1 ns; clk <= '0';
+    assert q = '0' and q_n = '1';
+
+    -- toggle using JK=11
+    j <= '1'; k <= '1';
+    clk <= '1'; wait for 1 ns; clk <= '0';
+    assert q = '1' and q_n = '0';
 
     wait;
   end process;

--- a/ttl/sn74138_tb.vhd
+++ b/ttl/sn74138_tb.vhd
@@ -44,10 +44,27 @@ begin
     );
 
   process
+    variable sel : unsigned(2 downto 0);
+    variable exp : std_logic_vector(7 downto 0);
   begin
-    wait for 5 ns;
+    g1  <= '1';
+    g2a <= '0';
+    g2b <= '0';
 
-    report "Testbench not implemented!" severity warning;
+    for i in 0 to 7 loop
+      sel := to_unsigned(i, 3);
+      a <= sel(2); b <= sel(1); c <= sel(0);
+      wait for 1 ns;
+
+      exp := (others => '1');
+      exp(7 - i) := '0';
+      assert (y7 & y6 & y5 & y4 & y3 & y2 & y1 & y0) = exp;
+    end loop;
+
+    -- disabled outputs when g1 is low
+    g1 <= '0';
+    wait for 1 ns;
+    assert (y7 & y6 & y5 & y4 & y3 & y2 & y1 & y0) = (others => '1');
 
     wait;
   end process;

--- a/ttl/sn74181_tb.vhd
+++ b/ttl/sn74181_tb.vhd
@@ -65,10 +65,39 @@ begin
     );
 
   process
+    variable f : std_logic_vector(3 downto 0);
   begin
-    wait for 5 ns;
+    -- arithmetic mode
+    m <= '0'; cin_n <= '1';
+    a3 <= '0'; a2 <= '0'; a1 <= '1'; a0 <= '1'; -- 3
+    b3 <= '0'; b2 <= '1'; b1 <= '0'; b0 <= '1'; -- 5
+    wait for 1 ns;
+    f := f3 & f2 & f1 & f0;
+    assert f = "1000" and cout_n = '1';
 
-    report "Testbench not implemented!" severity warning;
+    a3 <= '0'; a2 <= '1'; a1 <= '0'; a0 <= '1'; -- 5
+    b3 <= '0'; b2 <= '1'; b1 <= '0'; b0 <= '1'; -- 5
+    wait for 1 ns;
+    f := f3 & f2 & f1 & f0;
+    assert f = "1010" and cout_n = '1' and aeb = '1';
+
+    -- logic mode tests
+    m <= '1';
+    a3 <= '1'; a2 <= '1'; a1 <= '0'; a0 <= '0'; -- 12
+    b3 <= '1'; b2 <= '0'; b1 <= '1'; b0 <= '0'; -- 10
+    cin_n <= '1';
+
+    s3 <= '0'; s2 <= '0'; s1 <= '0'; s0 <= '0';
+    wait for 1 ns; assert (f3 & f2 & f1 & f0) = "1000";
+
+    s3 <= '0'; s2 <= '0'; s1 <= '0'; s0 <= '1';
+    wait for 1 ns; assert (f3 & f2 & f1 & f0) = "1110";
+
+    s3 <= '0'; s2 <= '0'; s1 <= '1'; s0 <= '0';
+    wait for 1 ns; assert (f3 & f2 & f1 & f0) = "0110";
+
+    s3 <= '0'; s2 <= '0'; s1 <= '1'; s0 <= '1';
+    wait for 1 ns; assert (f3 & f2 & f1 & f0) = "1001";
 
     wait;
   end process;

--- a/ttl/sn74244_tb.vhd
+++ b/ttl/sn74244_tb.vhd
@@ -53,9 +53,27 @@ begin
 
   process
   begin
-    wait for 5 ns;
+    -- A side enabled
+    ain0 <= '0'; ain1 <= '1'; ain2 <= '0'; ain3 <= '1';
+    aenb_n <= '0';
+    wait for 1 ns;
+    assert aout0 = ain0 and aout1 = ain1 and aout2 = ain2 and aout3 = ain3;
 
-    report "Testbench not implemented!" severity warning;
+    -- A side disabled
+    aenb_n <= '1';
+    wait for 1 ns;
+    assert aout0 = 'Z' and aout1 = 'Z' and aout2 = 'Z' and aout3 = 'Z';
+
+    -- B side enabled
+    bin0 <= '1'; bin1 <= '0'; bin2 <= '1'; bin3 <= '0';
+    benb_n <= '0';
+    wait for 1 ns;
+    assert bout0 = bin0 and bout1 = bin1 and bout2 = bin2 and bout3 = bin3;
+
+    -- B side disabled
+    benb_n <= '1';
+    wait for 1 ns;
+    assert bout0 = 'Z' and bout1 = 'Z' and bout2 = 'Z' and bout3 = 'Z';
 
     wait;
   end process;

--- a/ttl/sn74258_tb.vhd
+++ b/ttl/sn74258_tb.vhd
@@ -45,9 +45,26 @@ begin
 
   process
   begin
-    wait for 5 ns;
+    -- outputs should be high impedance when disabled
+    enb_n <= '1'; sel <= '0';
+    a0 <= '1'; a1 <= '0';
+    b0 <= '0'; b1 <= '1';
+    c0 <= '1'; c1 <= '0';
+    d0 <= '0'; d1 <= '1';
+    wait for 1 ns;
+    assert ay = 'Z' and by = 'Z' and cy = 'Z' and dy = 'Z';
 
-    report "Testbench not implemented!" severity warning;
+    -- select input 0
+    enb_n <= '0'; sel <= '0';
+    a0 <= '0'; b0 <= '1'; c0 <= '0'; d0 <= '1';
+    wait for 1 ns;
+    assert ay = a0 and by = b0 and cy = c0 and dy = d0;
+
+    -- select input 1
+    sel <= '1';
+    a1 <= '1'; b1 <= '0'; c1 <= '1'; d1 <= '0';
+    wait for 1 ns;
+    assert ay = a1 and by = b1 and cy = c1 and dy = d1;
 
     wait;
   end process;

--- a/ttl/sn74283_tb.vhd
+++ b/ttl/sn74283_tb.vhd
@@ -48,10 +48,30 @@ begin
     );
 
   process
+    variable f : std_logic_vector(3 downto 0);
   begin
-    wait for 5 ns;
+    -- 3 + 5 = 8
+    c0 <= '0';
+    a3 <= '0'; a2 <= '0'; a1 <= '1'; a0 <= '1';
+    b3 <= '0'; b2 <= '1'; b1 <= '0'; b0 <= '1';
+    wait for 1 ns;
+    f := s3 & s2 & s1 & s0;
+    assert f = "1000" and c4 = '0';
 
-    report "Testbench not implemented!" severity warning;
+    -- 15 + 1 = 16
+    a3 <= '1'; a2 <= '1'; a1 <= '1'; a0 <= '1';
+    b3 <= '0'; b2 <= '0'; b1 <= '0'; b0 <= '1';
+    wait for 1 ns;
+    f := s3 & s2 & s1 & s0;
+    assert f = "0000" and c4 = '1';
+
+    -- 6 + 7 + carry
+    c0 <= '1';
+    a3 <= '0'; a2 <= '1'; a1 <= '1'; a0 <= '0';
+    b3 <= '0'; b2 <= '1'; b1 <= '1'; b0 <= '1';
+    wait for 1 ns;
+    f := s3 & s2 & s1 & s0;
+    assert f = "1110" and c4 = '0';
 
     wait;
   end process;

--- a/ttl/sn74374_tb.vhd
+++ b/ttl/sn74374_tb.vhd
@@ -53,9 +53,33 @@ begin
 
   process
   begin
-    wait for 5 ns;
+    clk <= '0';
+    oenb_n <= '1';
 
-    report "Testbench not implemented!" severity warning;
+    -- load first value
+    i0 <= '0'; i1 <= '1'; i2 <= '0'; i3 <= '1';
+    i4 <= '0'; i5 <= '1'; i6 <= '0'; i7 <= '1';
+    clk <= '1'; wait for 1 ns; clk <= '0';
+
+    oenb_n <= '0';
+    wait for 1 ns;
+    assert (o7 & o6 & o5 & o4 & o3 & o2 & o1 & o0) = "10101010";
+
+    -- load second value
+    oenb_n <= '1';
+    i0 <= '1'; i1 <= '0'; i2 <= '1'; i3 <= '0';
+    i4 <= '1'; i5 <= '0'; i6 <= '1'; i7 <= '0';
+    clk <= '1'; wait for 1 ns; clk <= '0';
+
+    oenb_n <= '0';
+    wait for 1 ns;
+    assert (o7 & o6 & o5 & o4 & o3 & o2 & o1 & o0) = "01010101";
+
+    -- outputs disabled
+    oenb_n <= '1';
+    wait for 1 ns;
+    assert o0 = 'Z' and o1 = 'Z' and o2 = 'Z' and o3 = 'Z' and
+           o4 = 'Z' and o5 = 'Z' and o6 = 'Z' and o7 = 'Z';
 
     wait;
   end process;

--- a/ttl/sn7437_tb.vhd
+++ b/ttl/sn7437_tb.vhd
@@ -24,10 +24,29 @@ begin
     );
 
   process
+    type pt is record
+      a, b : std_logic;
+      y    : std_logic;
+    end record;
+    type pa is array(natural range <>) of pt;
+    constant p : pa :=
+      (('0','0','1'),
+       ('0','1','1'),
+       ('1','0','1'),
+       ('1','1','0'));
   begin
-    wait for 5 ns;
+    for i in p'range loop
+      g1a <= p(i).a; g1b <= p(i).b;
+      g2a <= p(i).a; g2b <= p(i).b;
+      g3a <= p(i).a; g3b <= p(i).b;
+      g4a <= p(i).a; g4b <= p(i).b;
 
-    report "Testbench not implemented!" severity warning;
+      wait for 1 ns;
+      assert g1y = p(i).y;
+      assert g2y = p(i).y;
+      assert g3y = p(i).y;
+      assert g4y = p(i).y;
+    end loop;
 
     wait;
   end process;


### PR DESCRIPTION
## Summary
- implement decoder test cases in `sn74138_tb.vhd`
- implement mux tests in `sn74258_tb.vhd`
- add arithmetic/logic coverage for `sn74181_tb.vhd`
- write simple read/write tests for `am93425a_tb.vhd`
- verify JK flip-flop operation in `ff_jk_tb.vhd`
- test buffer, NAND, adder, register and shift register TTL components

## Testing
- `ghdl --version` *(fails: command not found)*