### PR TITLE
Fix ROM address access with disabled chip

### DIFF
--- a/ttl/dm74472.vhd
+++ b/ttl/dm74472.vhd
@@ -47,8 +47,8 @@ begin
   process(all)
     variable data : std_logic_vector(7 downto 0);
   begin
-    data := rom(to_integer(addr));
     if ce_n = '0' then
+      data := rom(to_integer(addr));
       d7 <= data(7); d6 <= data(6); d5 <= data(5); d4 <= data(4);
       d3 <= data(3); d2 <= data(2); d1 <= data(1); d0 <= data(0);
     else

--- a/ttl/dm8221.vhd
+++ b/ttl/dm8221.vhd
@@ -47,8 +47,8 @@ begin
   process(all)
     variable word : std_logic_vector(1 downto 0);
   begin
-    word := ram(to_integer(addr));
     if ce = '1' then
+      word := ram(to_integer(addr));
       d0 <= word(0); d1 <= word(1);
     else
       d0 <= 'Z'; d1 <= 'Z';

--- a/ttl/im5600.vhd
+++ b/ttl/im5600.vhd
@@ -47,8 +47,8 @@ begin
   process(all)
     variable data : std_logic_vector(7 downto 0);
   begin
-    data := rom(to_integer(addr));
     if ce_n = '0' then
+      data := rom(to_integer(addr));
       o7 <= data(7); o6 <= data(6); o5 <= data(5); o4 <= data(4);
       o3 <= data(3); o2 <= data(2); o1 <= data(1); o0 <= data(0);
     else


### PR DESCRIPTION
## Summary
- guard RAM/ROM access by the enable pin in several TTL devices

## Testing
- `make -C ttl check` *(fails: `/root/hdlmake.mk/hdlmake.mk` not found)*