### PR TITLE
Fix sn74138_tb assertions

### DIFF
--- a/ttl/sn74138_tb.vhd
+++ b/ttl/sn74138_tb.vhd
@@ -59,14 +59,14 @@ begin
 
       exp := (others => '1');
       exp(7 - i) := '0';
-      assert (y7 & y6 & y5 & y4 & y3 & y2 & y1 & y0) = exp;
+      assert (y0 & y1 & y2 & y3 & y4 & y5 & y6 & y7) = exp;
     end loop;
 
     -- disabled outputs when g1 is low
     g1 <= '0';
     wait for 1 ns;
     exp := (others => '1');
-    assert (y7 & y6 & y5 & y4 & y3 & y2 & y1 & y0) = exp;
+    assert (y0 & y1 & y2 & y3 & y4 & y5 & y6 & y7) = exp;
 
     wait;
   end process;


### PR DESCRIPTION
This PR fixes the signal ordering in `sn74138_tb.vhd` so that the outputs are concatenated as `y0` .. `y7`. This ensures the expected vector `exp(7 - i)` is compared correctly. The testbench runs without assertion errors.

Created by OpenAI Codex.