### PR TITLE
Fix metavalue warnings in TTL memory tests

### DIFF
--- a/ttl/am93425a.vhd
+++ b/ttl/am93425a.vhd
@@ -18,7 +18,7 @@ end am93425a;
 architecture ttl of am93425a is
   type ram_t is array (0 to 1023) of std_logic;
   signal ram  : ram_t := (others => '0');
-  signal addr : unsigned(9 downto 0);
+  signal addr : unsigned(9 downto 0) := (others => '0');
 begin
   addr <= a9 & a8 & a7 & a6 & a5 & a4 & a3 & a2 & a1 & a0;
 

--- a/ttl/am93425a_tb.vhd
+++ b/ttl/am93425a_tb.vhd
@@ -9,20 +9,21 @@ end;
 
 architecture testbench of am93425a_tb is
 
-  signal a0   : std_logic;
-  signal a1   : std_logic;
-  signal a2   : std_logic;
-  signal a3   : std_logic;
-  signal a4   : std_logic;
-  signal a5   : std_logic;
-  signal a6   : std_logic;
-  signal a7   : std_logic;
-  signal a8   : std_logic;
-  signal a9   : std_logic;
-  signal ce_n : std_logic;
-  signal we_n : std_logic;
-  signal di   : std_logic;
-  signal do   : std_logic;
+  -- Initialize signals to avoid metavalue assertions from ieee.numeric_std
+  signal a0   : std_logic := '0';
+  signal a1   : std_logic := '0';
+  signal a2   : std_logic := '0';
+  signal a3   : std_logic := '0';
+  signal a4   : std_logic := '0';
+  signal a5   : std_logic := '0';
+  signal a6   : std_logic := '0';
+  signal a7   : std_logic := '0';
+  signal a8   : std_logic := '0';
+  signal a9   : std_logic := '0';
+  signal ce_n : std_logic := '0';
+  signal we_n : std_logic := '0';
+  signal di   : std_logic := '0';
+  signal do   : std_logic := '0';
 
 begin
 

--- a/ttl/dm74472.vhd
+++ b/ttl/dm74472.vhd
@@ -40,7 +40,7 @@ architecture ttl of dm74472 is
   end function;
 
   signal rom  : rom_t := load_rom;
-  signal addr : unsigned(8 downto 0);
+  signal addr : unsigned(8 downto 0) := (others => '0');
 begin
   addr <= a8 & a7 & a6 & a5 & a4 & a3 & a2 & a1 & a0;
 

--- a/ttl/dm74472_tb.vhd
+++ b/ttl/dm74472_tb.vhd
@@ -12,24 +12,25 @@ end;
 
 architecture testbench of dm74472_tb is
 
-  signal a8   : std_logic;
-  signal a7   : std_logic;
-  signal a6   : std_logic;
-  signal a5   : std_logic;
-  signal ce_n : std_logic;
-  signal d7   : std_logic;
-  signal d6   : std_logic;
-  signal d5   : std_logic;
-  signal d4   : std_logic;
-  signal d3   : std_logic;
-  signal d2   : std_logic;
-  signal d1   : std_logic;
-  signal d0   : std_logic;
-  signal a4   : std_logic;
-  signal a3   : std_logic;
-  signal a2   : std_logic;
-  signal a1   : std_logic;
-  signal a0   : std_logic;
+  -- Initialize signals to avoid metavalue assertions from ieee.numeric_std
+  signal a8   : std_logic := '0';
+  signal a7   : std_logic := '0';
+  signal a6   : std_logic := '0';
+  signal a5   : std_logic := '0';
+  signal ce_n : std_logic := '0';
+  signal d7   : std_logic := '0';
+  signal d6   : std_logic := '0';
+  signal d5   : std_logic := '0';
+  signal d4   : std_logic := '0';
+  signal d3   : std_logic := '0';
+  signal d2   : std_logic := '0';
+  signal d1   : std_logic := '0';
+  signal d0   : std_logic := '0';
+  signal a4   : std_logic := '0';
+  signal a3   : std_logic := '0';
+  signal a2   : std_logic := '0';
+  signal a1   : std_logic := '0';
+  signal a0   : std_logic := '0';
 
   type rom_t is array (0 to 511) of std_logic_vector(7 downto 0);
 

--- a/ttl/im5600.vhd
+++ b/ttl/im5600.vhd
@@ -40,7 +40,7 @@ architecture ttl of im5600 is
   end function;
 
   signal rom  : rom_t := load_rom;
-  signal addr : unsigned(4 downto 0);
+  signal addr : unsigned(4 downto 0) := (others => '0');
 begin
   addr <= a4 & a3 & a2 & a1 & a0;
 

--- a/ttl/im5600_tb.vhd
+++ b/ttl/im5600_tb.vhd
@@ -12,20 +12,21 @@ end;
 
 architecture testbench of im5600_tb is
 
-  signal o7   : std_logic;
-  signal o6   : std_logic;
-  signal o5   : std_logic;
-  signal o4   : std_logic;
-  signal o3   : std_logic;
-  signal o2   : std_logic;
-  signal o1   : std_logic;
-  signal o0   : std_logic;
-  signal a4   : std_logic;
-  signal a3   : std_logic;
-  signal a2   : std_logic;
-  signal a1   : std_logic;
-  signal a0   : std_logic;
-  signal ce_n : std_logic;
+  -- Initialize signals to avoid metavalue assertions from ieee.numeric_std
+  signal o7   : std_logic := '0';
+  signal o6   : std_logic := '0';
+  signal o5   : std_logic := '0';
+  signal o4   : std_logic := '0';
+  signal o3   : std_logic := '0';
+  signal o2   : std_logic := '0';
+  signal o1   : std_logic := '0';
+  signal o0   : std_logic := '0';
+  signal a4   : std_logic := '0';
+  signal a3   : std_logic := '0';
+  signal a2   : std_logic := '0';
+  signal a1   : std_logic := '0';
+  signal a0   : std_logic := '0';
+  signal ce_n : std_logic := '0';
 
   type rom_t is array (0 to 31) of std_logic_vector(7 downto 0);
 


### PR DESCRIPTION
This pull request, created by OpenAI Codex, initializes all signals in the
AM93425A, IM5600 and DM74472 memory testbenches. It also initializes the
address signals inside the corresponding memory models. These changes prevent
`numeric_std` from reporting metavalue warnings during simulation.