### PR TITLE
Add ff_jkpc testbench stimulus

### DIFF
--- a/ttl/ff_jkpc_tb.vhd
+++ b/ttl/ff_jkpc_tb.vhd
@@ -1,6 +1,8 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
+-- Testbench created by OpenAI Codex
+
 library ttl;
 use ttl.misc.all;
 
@@ -28,13 +30,32 @@ begin
     q_n => q_n
     );
 
+  -- Stimulus created by OpenAI Codex
   process
   begin
-    wait for 5 ns;
+    clk <= '0';
+    j   <= '0';
+    k   <= '0';
 
-    report "Testbench not implemented!" severity warning;
+    -- asynchronous clear
+    pre <= '1'; clr <= '0';
+    wait for 1 ns;
+    assert q = '0' and q_n = '1';
+
+    -- asynchronous preset
+    clr <= '1'; pre <= '0';
+    wait for 1 ns;
+    assert q = '1' and q_n = '0';
+
+    -- when both preset and clear are inactive, value should hold
+    pre <= '1'; clr <= '1';
+    for i in 1 to 3 loop
+      clk <= '1'; wait for 1 ns; clk <= '0'; wait for 1 ns;
+      assert q = '1' and q_n = '0';
+    end loop;
 
     wait;
   end process;
 
 end;
+


### PR DESCRIPTION
## Summary
- implement stimulus for `ff_jkpc_tb` verifying clear, preset and hold
- attribute the testbench to OpenAI Codex

## Testing
- `ghdl -a --std=08 --work=ttl ttl/misc.vhd`
- `ghdl -a --std=08 --work=ttl ttl/ff_jk.vhd ttl/ff_jkpc.vhd ttl/ff_jkpc_tb.vhd`
- `ghdl -e --std=08 --work=ttl -Pttl ff_jkpc_tb`
- `ghdl -r --std=08 --work=ttl -Pttl ff_jkpc_tb` *(fails: assertion violation)*
